### PR TITLE
Add Empirical as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "source/third-party/empirical"]
+	path = source/third-party/empirical
+	url = git@github.com:devosoft/Empirical

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,4 +1,4 @@
-EMP_DIR := ../../Empirical/include
+EMP_DIR := ../source/third-party/empirical/include
 MABE_DIR := ../source
 
 # Flags to use regardless of compiler


### PR DESCRIPTION
Main contributions: 
1. Adds Empirical (the core of MABE2) as a git submodule that can easily be downloaded with this repository
2. Modifies the Makefile in `./build` to point to the Empirical submodule

Additional notes:
- By adding `--recursive` to your git clone of this repo, git will download MABE2, Empirical, and all of Empirical's submodules (e.g., `git clone git@github.com:mercere/MABE2 --recursive`)
- Recursively downloading submodules also gives us access to Catch2, which is very likely what we'll use for testing in MABE2!
- End users _should_ not need to edit the Makefile, while it is still totally accessible if needed (e.g., for folks who are also developing Empirical alongside MABE2)
- Three of the commits were just me updating my fork to match master at `mercere99/MABE2` haha