### PR TITLE
Change empirical dependency to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source/third-party/empirical"]
 	path = source/third-party/empirical
-	url = git@github.com:devosoft/Empirical
+	url = https://github.com/devosoft/Empirical.git


### PR DESCRIPTION
This time I correctly checked out the branch with only this change...

Changing from SSH to HTTPS allows 3rd party APIs (like readthedocs) and people who do not have SSH set up to successfuly use mabe